### PR TITLE
So I was looking at your code and saw a misspelled word (change 'puncuated' -> 'punctuated').

### DIFF
--- a/lib/attributeGrammar.js
+++ b/lib/attributeGrammar.js
@@ -16,7 +16,7 @@ module.exports = require('hot-cocoa').analyzer({
   '_expression': function(tree) {
     return this.analyze(tree[0]);
   },
-  '_puncuated-list': function(tree) {
+  '_punctuated-list': function(tree) {
     var result = types('list', [], tree[0].position);
     switch (tree[0].type) {
     case '\'' :

--- a/lib/parseGrammar.json
+++ b/lib/parseGrammar.json
@@ -7,7 +7,7 @@
     []
   ],
   "_expression": [
-    ["_puncuated-list"],
+    ["_punctuated-list"],
     ["_dotted-chain"],
     ["_list"],
     ["_dotted-list"],
@@ -15,7 +15,7 @@
     ["_object"],
     ["_atom"]
   ],
-  "_puncuated-list": [
+  "_punctuated-list": [
     ["'", "_expression"],
     ["`", "_expression"],
     ["~", "_expression"]


### PR DESCRIPTION
(tested to not to change the current behavior:

hcl> ~[]
[ReferenceError unquote is not defined]
hcl> `[]
[SyntaxError Unexpected token )]
hcl> '[]
[ReferenceError list is not defined]
